### PR TITLE
Allow interval to be null

### DIFF
--- a/src/components/pages/simulation/views/simulationForm.js
+++ b/src/components/pages/simulation/views/simulationForm.js
@@ -139,7 +139,7 @@ class SimulationForm extends LinkedComponent {
       ? simulation.deviceModels[0].count
       : 0;
     const interval = simulation.deviceModels.length && simulation.deviceModels[0].interval;
-    const [hours, minutes, seconds] = (interval || '00:00:00').split(':');
+    const [hours, minutes, seconds] = (interval || '00:00:10').split(':');
     const iotHubString = (simulation || {}).connectionString || '';
     const preProvisionedRadio = iotHubString === '' ? 'preProvisioned' : 'customString';
     const sensors = simulation.deviceModels.length


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation
- Fix issue where device model interval value is undefined
- Fix issue where on loading a form with a hub string, the string would be visible