### PR TITLE
update correct property for preprovisioned hub

### DIFF
--- a/src/components/pages/simulation/views/simulationForm.js
+++ b/src/components/pages/simulation/views/simulationForm.js
@@ -141,7 +141,7 @@ class SimulationForm extends LinkedComponent {
     const interval = (simulation.deviceModels.length && simulation.deviceModels[0].interval) || '00:00:10';
     const [hours, minutes, seconds] = interval.split(':');
     const iotHubString = (simulation || {}).connectionString || '';
-    const preProvisionedRadio = preprovisionedIoTHubInUse && iotHubString === '' ? 'preProvisioned' : 'customString';
+    const preProvisionedRadio = preprovisionedIoTHub && iotHubString === '' ? 'preProvisioned' : 'customString';
     const sensors = simulation.deviceModels.length
       ? (simulation.deviceModels[0].sensors || []).map(this.toSensorReplicable)
       : [];


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
- Corrected property `preprovisionedIoTHubInUse` to `preprovisionedIoTHub`

Fixes https://github.com/Azure/pcs-simulation-webui/issues/112

**Checklist:**

- [x] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
