### PR TITLE
Force refresh to update from server rather than cache

### DIFF
--- a/src/components/pages/simulation/views/simulationDetails.js
+++ b/src/components/pages/simulation/views/simulationDetails.js
@@ -118,7 +118,7 @@ class SimulationDetails extends Component {
     };
 
     if (this.state.pollingError) {
-      const refreshPage = () => window.location.reload();
+      const refreshPage = () => window.location.reload(true);
 
       return (
         <FormActions className="details-form-actions">


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation
When the user selects the refresh button on a polling error, force browser to update from the server instead of local cache. I think this will handle the auth failure case in a single click rather than two.