### PR TITLE
Avoid printing 'undefined' in class

### DIFF
--- a/src/utilities/methods.js
+++ b/src/utilities/methods.js
@@ -10,7 +10,7 @@ export const isObject = value => typeof value === 'object';
 export const int = (num) => parseInt(num, 10);
 
 /** Merges css classnames into a single string */
-export const joinClasses = (...classNames) => classNames.join(' ').trim();
+export const joinClasses = (...classNames) => classNames.filter(name => !!name).join(' ').trim();
 
 /** Convert a string of type 'true' or 'false' to its boolean equivalent */
 export const stringToBoolean = value => {


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
The current version of joinClasses will return the string 'undefined' for undefined values. This change prevents that from happening by filtering them out.