### PR TITLE
Log start simulation data from payload

### DIFF
--- a/src/store/reducers/simulationReducer.js
+++ b/src/store/reducers/simulationReducer.js
@@ -90,12 +90,12 @@ export const epics = createEpicScenario({
       const deviceModels = payload.deviceModels.length > 0 ? payload.deviceModels[0] : {};
       const eventProps = {
         DeviceModels: [{
-          Id: hasDeviceModels ? deviceModels.id: '',
-          Name: hasDeviceModels ? deviceModels.defaultDeviceModel.name: '',
+          Id: hasDeviceModels ? deviceModels.id : '',
+          Name: hasDeviceModels ? deviceModels.defaultDeviceModel.name : '',
           Count: hasDeviceModels ? deviceModels.count : 0,
           Frequency: hasDeviceModels ? deviceModels.interval : '',
           IsCustomDevice: hasDeviceModels ? payload.deviceModels[0].isCustomDevice : null,
-          Sensors: deviceModels.sensors,
+          Sensors: hasDeviceModels ? deviceModels.sensors : {},
       }]};
       const event = diagnosticsEvent('StartSimulation', eventProps);
       // Force the simulation status to update if turned off


### PR DESCRIPTION
# Type of change? 

- [X] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation 

Redux store is only updated when user clicks "startsimulation" button and not when they enter any input in the form. So the store holds data from older simulation run (which was already stopped) which can differ from what is currently filled out/updated on the form. Use data from payload instead of store when logging data on start simulation.

**Checklist:**

- [X] All tests passed
- [X] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
