### PR TITLE
Fixing the sort order in Adding a new simulation

### DIFF
--- a/src/components/pages/simulation/views/simulationForm.js
+++ b/src/components/pages/simulation/views/simulationForm.js
@@ -130,7 +130,7 @@ class SimulationForm extends LinkedComponent {
     } = props;
     const deviceModelOptions = [
       { value: Config.customSensorValue, label: 'Custom' },
-      ...(deviceModels || []).map(this.toSelectOption).sort((a,b)=>a.label.localeCompare(b.label))
+      ...(deviceModels || []).map(this.toSelectOption).sort((a,b) => a.label.localeCompare(b.label))
     ];
     const hasDeviceModels = simulation.deviceModels.length > 0;
     const deviceModel = hasDeviceModels


### PR DESCRIPTION
Sorting the dropdown in Start Simulation in ascending order
