### PR TITLE
Fixing default value for interval - should be empty object instead of string

### DIFF
--- a/src/components/pages/simulation/views/simulationForm.js
+++ b/src/components/pages/simulation/views/simulationForm.js
@@ -25,7 +25,7 @@ const newDeviceModel = () => ({
   name: '',
   count: 0,
   messageThroughput: '',
-  interval: ''
+  interval: {}
 });
 
 const isIntRegex = /^-?\d*$/;


### PR DESCRIPTION
Fixing default value for interval - should be empty object instead of string

# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

...

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
