### PR TITLE
Adding ability to delete all devices even after the simulation is stopped.

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -60,6 +60,7 @@
         "runIndefinitelyBtn": "Run indefinitely"
       },
       "deleteDevicesWhenSimulationEnds": "Delete all devices when the simulation is complete",
+      "deleteAllDevices": "Delete All Devices",
       "errorMsg": {
         "duplicateModelsNotAllowed": "A device model may be used only once",
         "nameCantBeEmpty": "Simulation name is required",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -60,7 +60,7 @@
         "runIndefinitelyBtn": "Run indefinitely"
       },
       "deleteDevicesWhenSimulationEnds": "Delete all devices when the simulation is complete",
-      "deleteAllDevices": "Delete All Devices",
+      "deleteAllDevices": "Delete all devices",
       "errorMsg": {
         "duplicateModelsNotAllowed": "A device model may be used only once",
         "nameCantBeEmpty": "Simulation name is required",

--- a/src/components/pages/simulation/views/simulationDetails.js
+++ b/src/components/pages/simulation/views/simulationDetails.js
@@ -65,7 +65,7 @@ class SimulationDetails extends Component {
       .subscribe(
         response => {
           const devicesDeletionInProgress = !response.enabled
-            && response.devicesDeletionRequired
+            && (response.devicesDeletionRequired || response.deleteDevicesOnce)
             && !response.devicesDeletionCompleted;
 
           this.setState({
@@ -84,6 +84,7 @@ class SimulationDetails extends Component {
             simulationPollingError: '',
             devicesDeletionInProgress,
             devicesDeletionRequired: response.devicesDeletionRequired,
+            deleteDevicesWhenSimulationEnds: response.deleteDevicesWhenSimulationEnds,
             devicesDeletionCompleted: response.devicesDeletionCompleted
           },
           () => {
@@ -288,7 +289,7 @@ class SimulationDetails extends Component {
       .subscribe(
         response => {
           const devicesDeletionInProgress = !response.enabled
-            && response.devicesDeletionRequired
+            && (response.devicesDeletionRequired || response.deleteDevicesOnce)
             && !response.devicesDeletionCompleted;
           this.setState({ devicesDeletionInProgress, devicesDeletionCompleted: response.devicesDeletionCompleted },
             () => {

--- a/src/components/pages/simulation/views/simulationDetails.js
+++ b/src/components/pages/simulation/views/simulationDetails.js
@@ -357,7 +357,7 @@ class SimulationDetails extends Component {
       simulationList
     } = this.props;
 
-    const { simulation, metrics, hubMetricsPollingError, simulationPollingError, preprovisionedIoTHubInUse, devicesDeletionCompleted, enabled, devicesDeletionInProgress } = this.state;
+    const { simulation, metrics, hubMetricsPollingError, simulationPollingError, preprovisionedIoTHubInUse, enabled, devicesDeletionInProgress, devicesDeletionCompleted } = this.state;
     const pollingError = hubMetricsPollingError || simulationPollingError;
 
     const {

--- a/src/components/pages/simulation/views/simulationDetails.js
+++ b/src/components/pages/simulation/views/simulationDetails.js
@@ -438,7 +438,7 @@ class SimulationDetails extends Component {
                     <div className="right-time-container">{ this.getSimulationState(endDateTime, t) }</div>
                   </div>
                   {
-                    !devicesDeletionCompleted && !enabled &&
+                    !devicesDeletionCompleted && !enabled && stopTime != null &&
                     <div className="info-section">
                       <Btn className="delete-devices-section" disabled={devicesDeletionInProgress} onClick={this.deleteDevicesInThisSimulation}>{t('simulation.form.deleteAllDevices')}</Btn>
                     </div>

--- a/src/components/pages/simulation/views/simulationDetails.js
+++ b/src/components/pages/simulation/views/simulationDetails.js
@@ -35,8 +35,8 @@ class SimulationDetails extends Component {
       telemetry: {},
       metrics:[],
       isRunning : false,
-      showLink : false,
-      hubUrl : '',
+      preprovisionedIoTHubInUse: undefined,
+      hubUrl: '',
       simulationPollingError: '',
       hubMetricsPollingError: ''
     };
@@ -80,7 +80,7 @@ class SimulationDetails extends Component {
             failedDeviceConnectionsCount: response.statistics.failedDeviceConnectionsCount,
             failedDeviceTwinUpdatesCount: response.statistics.failedDeviceTwinUpdatesCount,
             hubUrl: ((response.iotHubs || [])[0] || {}).preprovisionedIoTHubMetricsUrl || '',
-            showLink: ((response.iotHubs || [])[0] || {}).preprovisionedIoTHubInUse,
+            preprovisionedIoTHubInUse: ((response.iotHubs || [])[0] || {}).preprovisionedIoTHubInUse,
             simulationPollingError: '',
             devicesDeletionInProgress
           },
@@ -176,7 +176,7 @@ class SimulationDetails extends Component {
   }
 
   getHubLink = () => {
-    return this.state.showLink && (
+    return this.state.preprovisionedIoTHubInUse && (
       <ComponentArray>
         <Svg path={svgs.linkTo} className="link-svg" />
         <a href={this.state.hubUrl} target="_blank">{ this.props.t('simulation.vieIotHubMetrics') }</a>
@@ -330,11 +330,10 @@ class SimulationDetails extends Component {
       t,
       deviceModelEntities = {},
       match,
-      simulationList,
-      preprovisionedIoTHub
+      simulationList
     } = this.props;
 
-    const { simulation, metrics, hubMetricsPollingError, simulationPollingError } = this.state;
+    const { simulation, metrics, hubMetricsPollingError, simulationPollingError, preprovisionedIoTHubInUse } = this.state;
     const pollingError = hubMetricsPollingError || simulationPollingError;
 
     const {
@@ -422,7 +421,7 @@ class SimulationDetails extends Component {
               <div className="simulation-statistics">{ id && this.getSimulationStats() }</div>
             </div>
             {
-              id && isDef(preprovisionedIoTHub) && (preprovisionedIoTHub
+              id && isDef(preprovisionedIoTHubInUse) && (preprovisionedIoTHubInUse
                 ? hubMetricsPollingError
                     ? insufficientPermissionsError
                       ? this.getMetricsPlaceHolder(t('simulation.details.insufficientPermissions'))

--- a/src/components/pages/simulation/views/simulationDetails.scss
+++ b/src/components/pages/simulation/views/simulationDetails.scss
@@ -134,10 +134,10 @@ $svgSize: 16px;
         .info-container { border-bottom: 1px solid themed('colorMidSecond'); }
 
         .info-section  .delete-devices-section {
-          background: $colorGrayLight;
+          background: themed('colorGrayLight');
 
           &:hover {
-            background: $colorGrayDark;
+            background: themed('colorGrayDark');
           }
         }
         .status-description { color: themed('colorLightestFirst'); }

--- a/src/components/pages/simulation/views/simulationDetails.scss
+++ b/src/components/pages/simulation/views/simulationDetails.scss
@@ -11,7 +11,6 @@ $svgSize: 16px;
 
   .simulation-stats-container {
     display: flex;
-    @include rem-fallback(height, 500px);
 
     .stack-container {
       @include rem-fallback(width, 580px);
@@ -30,6 +29,11 @@ $svgSize: 16px;
             overflow: hidden;
             text-overflow: ellipsis;
             @include rem-fallback(max-width, 350px);
+          }
+
+          .delete-devices-section {
+            @include rem-fallback(margin-top, 20px);
+            @include rem-fallback(height, 32px);
           }
         }
 
@@ -129,6 +133,13 @@ $svgSize: 16px;
 
         .info-container { border-bottom: 1px solid themed('colorMidSecond'); }
 
+        .info-section  .delete-devices-section {
+          background: $colorGrayLight;
+
+          &:hover {
+            background: $colorGrayDark;
+          }
+        }
         .status-description { color: themed('colorLightestFirst'); }
 
         .info-label,

--- a/src/services/models/simulationModels.js
+++ b/src/services/models/simulationModels.js
@@ -54,7 +54,7 @@ export const toSimulationModel = (response = {}) => ({
   iotHubs: (response.IoTHubs || []).map(({ ConnectionString, PreprovisionedIoTHub, PreprovisionedIoTHubInUse, PreprovisionedIoTHubMetricsUrl }) => ({
     connectionString: ConnectionString === 'default' ? '' : ConnectionString,
     preprovisionedIoTHub: PreprovisionedIoTHub,
-    preprovisionedIoTHubInUse: PreprovisionedIoTHubInUse,
+    preprovisionedIoTHubInUse: ConnectionString === 'default',
     preprovisionedIoTHubMetricsUrl: PreprovisionedIoTHubMetricsUrl
   })),
   devicesDeletionRequired: response.DeleteDevicesWhenSimulationEnds,

--- a/src/services/models/simulationModels.js
+++ b/src/services/models/simulationModels.js
@@ -58,6 +58,7 @@ export const toSimulationModel = (response = {}) => ({
     preprovisionedIoTHubMetricsUrl: PreprovisionedIoTHubMetricsUrl
   })),
   devicesDeletionRequired: response.DeleteDevicesWhenSimulationEnds,
+  deleteDevicesOnce: response.DeleteDevicesOnce,
   devicesDeletionCompleted: response.DevicesDeletionComplete
 });
 
@@ -109,7 +110,7 @@ export const toSimulationPatchModel = (request = {}, enabled) => ({
 export const deviceDeletionPatchModel = (request = {}, deleteDevices) => ({
   ETag: request.eTag,
   Id: request.id,
-  DeleteDevicesWhenSimulationEnds: true
+  DeleteDevicesOnce: true
 });
 
 // Map to deviceModels in simulation request model

--- a/src/services/models/simulationModels.js
+++ b/src/services/models/simulationModels.js
@@ -106,6 +106,12 @@ export const toSimulationPatchModel = (request = {}, enabled) => ({
   Enabled: enabled
 });
 
+export const deviceDeletionPatchModel = (request = {}, deleteDevices) => ({
+  ETag: request.eTag,
+  Id: request.id,
+  DeleteDevicesWhenSimulationEnds: true
+});
+
 // Map to deviceModels in simulation request model
 const toDeviceModels = (deviceModels = []) =>
   deviceModels.map(({ name: Id, count: Count, interval }) => {

--- a/src/services/simulationService.js
+++ b/src/services/simulationService.js
@@ -2,7 +2,7 @@
 
 import Config from 'app.config';
 import { HttpClient } from './httpClient';
-import { toSimulationStatusModel, toSimulationModel, toSimulationListModel, toDeviceModel, toSimulationRequestModel, toSimulationCloneModel, toSimulationPatchModel } from './models';
+import { toSimulationStatusModel, toSimulationModel, toSimulationListModel, toDeviceModel, toSimulationRequestModel, toSimulationCloneModel, toSimulationPatchModel, deviceDeletionPatchModel } from './models';
 import { Observable } from 'rxjs/Observable';
 
 const ENDPOINT = Config.simulationApiUrl;
@@ -77,6 +77,16 @@ export class SimulationService {
     return HttpClient.patch(
         `${ENDPOINT}simulations/${simulation.id}`,
         toSimulationPatchModel(simulation, false)
+      )
+      .map(toSimulationModel)
+      .catch(resolveConflict);
+  }
+
+  /** Patch a simulation */
+  static patchSimulation(simulation) {
+    return HttpClient.patch(
+      `${ENDPOINT}simulations/${simulation.id}`,
+      deviceDeletionPatchModel(simulation, true)
       )
       .map(toSimulationModel)
       .catch(resolveConflict);

--- a/src/store/reducers/appReducer.js
+++ b/src/store/reducers/appReducer.js
@@ -62,7 +62,7 @@ export const epics = createEpicScenario({
     epic: ({ payload }, store) => {
       const settings = getSolutionSettings(store.getState());
       const diagnosticsOptOut = settings === undefined ? true : settings.diagnosticsOptOut;
-      payload.eventProperties.sessionId = sessionId;
+      (payload.eventProperties||{}).sessionId = sessionId;
       if (!diagnosticsOptOut) {
         return DiagnosticsService.logEvent(payload)
           .flatMap(_ => Observable.empty())

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -52,7 +52,9 @@ $themes: (
     // Modal - END
 
     // Form - START
-    colorGray : $colorGray,
+    colorGray: $colorGray,
+    colorGrayLight: $colorGrayLight,
+    colorGrayDark:$colorGrayDark,
     colorCharcoalLight: $colorCharcoalLight,
     // Form - EED
   ),

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -28,6 +28,8 @@ $colorBlue: #136bfb;
 $colorBlack: #000;
 $colorBlueDark: #00418C;
 $colorGray: #e5e5e5;
+$colorGrayLight: #2D2F33;
+$colorGrayDark: #3F3F3F;
 
 // Color variables - for light theme
 $colorAluminum: #dadae0;


### PR DESCRIPTION
Currently, user can choose to delete devices associated with a simulation only while creating a new simulation.

In this PR, we are adding functionality to delete devices associated with the simulation after the simulation has stopped.