### PR TITLE
Properly escaping telemetry message template

### DIFF
--- a/src/services/models/deviceModelsModel.js
+++ b/src/services/models/deviceModelsModel.js
@@ -51,8 +51,8 @@ const toCustomSensorModel = (sensors = []) => {
     .forEach(({ name, behavior, minValue, maxValue, unit }) => {
       const _name = name.toLowerCase();
       const _unit = unit.toLowerCase();
-      const nameString = `'${_name}':$\{${_name}}`;
-      const unitString = `'${_name}_unit':'${_unit}'`;
+      const nameString = `"${_name}":$\{${_name}}`;
+      const unitString = `"${_name}_unit":"${_unit}"`;
       const path = behavior.value;
       messages = [...messages, nameString, unitString];
       Fields = { ...Fields, [_name]: 'double', [`${_name}_unit`]: 'text' };


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->

This is a fix for #216. The fix is to use double-quotes for the MessageTemplate component of device models. 

**Checklist:**

- [ ] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
